### PR TITLE
use the local path for the url query parameter

### DIFF
--- a/src/SwaggerWcf/SwaggerWcfEndpoint.cs
+++ b/src/SwaggerWcf/SwaggerWcfEndpoint.cs
@@ -70,7 +70,7 @@ namespace SwaggerWcf
 
             if (string.IsNullOrWhiteSpace(content))
             {
-                string swaggerUrl = woc.IncomingRequest.UriTemplateMatch.BaseUri + "/swagger.json";
+                string swaggerUrl = woc.IncomingRequest.UriTemplateMatch.BaseUri.LocalPath + "/swagger.json";
                 woc.OutgoingResponse.StatusCode = HttpStatusCode.Redirect;
                 woc.OutgoingResponse.Location = "index.html?url=" + swaggerUrl;
                 return null;


### PR DESCRIPTION
Hi!

We have this behind a load balancer which is providing https for us. It can rewrite the port and protocol for us, but it doesn't handle them in the url query parameter.

Changing the url to be the LocalPath, ie. /api-docs instead of http://localhost/api-docs solved this for us.

I believe this implementation is backwards compatible.