### PR TITLE
Allow nested lists to be correctly processed

### DIFF
--- a/src/SwaggerWcf/Support/DefinitionsBuilder.cs
+++ b/src/SwaggerWcf/Support/DefinitionsBuilder.cs
@@ -207,7 +207,7 @@ namespace SwaggerWcf.Support
 
             if (prop.TypeFormat.Type == ParameterType.Array)
             {
-                Type subType = propertyInfo.PropertyType.GetEnumerableType();
+                Type subType = GetEnumerableType(propertyInfo.PropertyType);
                 if (subType != null)
                 {
                     TypeFormat subTypeFormat = Helpers.MapSwaggerType(subType, null);

--- a/src/SwaggerWcf/Support/Mapper.cs
+++ b/src/SwaggerWcf/Support/Mapper.cs
@@ -342,13 +342,13 @@ namespace SwaggerWcf.Support
         private IEnumerable<string> GetConsumes(MethodInfo implementation, MethodInfo declaration)
         {
             List<string> contentTypes = new List<string>();
-            if (declaration.GetCustomAttributes<WebGetAttribute>().Any())
+            if (declaration.GetCustomAttributes<WebGetAttribute>().Any(a => a.IsRequestFormatSetExplicitly))
             {
                 contentTypes.AddRange(
                     declaration.GetCustomAttributes<WebGetAttribute>()
                                .Select(a => ConvertWebMessageFormatToContentType(a.RequestFormat)));
             }
-            else if (declaration.GetCustomAttributes<WebInvokeAttribute>().Any())
+            else if (declaration.GetCustomAttributes<WebInvokeAttribute>().Any(a => a.IsRequestFormatSetExplicitly))
             {
                 contentTypes.AddRange(
                     declaration.GetCustomAttributes<WebInvokeAttribute>()
@@ -363,13 +363,13 @@ namespace SwaggerWcf.Support
         private IEnumerable<string> GetProduces(MethodInfo implementation, MethodInfo declaration)
         {
             List<string> contentTypes = new List<string>();
-            if (declaration.GetCustomAttributes<WebGetAttribute>().Any())
+            if (declaration.GetCustomAttributes<WebGetAttribute>().Any(a => a.IsResponseFormatSetExplicitly))
             {
                 contentTypes.AddRange(
                     declaration.GetCustomAttributes<WebGetAttribute>()
                                .Select(a => ConvertWebMessageFormatToContentType(a.ResponseFormat)));
             }
-            else if (declaration.GetCustomAttributes<WebInvokeAttribute>().Any())
+            else if (declaration.GetCustomAttributes<WebInvokeAttribute>().Any(a => a.IsResponseFormatSetExplicitly))
             {
                 contentTypes.AddRange(
                     declaration.GetCustomAttributes<WebInvokeAttribute>()


### PR DESCRIPTION
Hello,

The first commit allowed my class with a nested list to be properly processed. Example:

 ` 

    public class A {
        public int id { get; set; }
        public string name { get; set; }
        public BList bEntries { get; set; }

    }

    public class BList : List<B> {
        public BList() { }
        public BList(IEnumerable<B> entries) : base(entries) { }

    }

    public class B 
    {
        public int id { get; set; }
        public string name { get; set; }
        public CList cEntries { get; set; }
    }

    public class CList : List<C> { }

    public class C : CxtBase
    {
        public int id { get; set; }
        public string description { get; set; }
        public string value { get; set; }
    }
`

The second commit causes the swagger.json output to contain *both* application/xml and application/json if the corresponding produces/consumes attribute is not explicitly set in the WebInvoke or WebGet attributes