### PR TITLE
Unwrap null-able types and treat them as optional to eliminate ugly m…

### DIFF
--- a/src/SwaggerWcf/Support/DefinitionsBuilder.cs
+++ b/src/SwaggerWcf/Support/DefinitionsBuilder.cs
@@ -190,6 +190,16 @@ namespace SwaggerWcf.Support
                 prop.Required = dataMemberAttribute.IsRequired;
             }
 
+            // Special case - if it came out required, but we unwrapped a null-able type,
+            // then it's necessarily not required.  Ideally this would only set the default,
+            // but we can't tell the difference between an explicit delaration of
+            // IsRequired =false on the DataMember attribute and no declaration at all.
+            if (prop.Required && propertyInfo.PropertyType.IsGenericType &&
+                propertyInfo.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                prop.Required = false;
+            }
+
             DescriptionAttribute descriptionAttribute = propertyInfo.GetCustomAttribute<DescriptionAttribute>();
             if (descriptionAttribute != null)
                 prop.Description = descriptionAttribute.Description;

--- a/src/SwaggerWcf/Support/Helpers.cs
+++ b/src/SwaggerWcf/Support/Helpers.cs
@@ -107,6 +107,12 @@ namespace SwaggerWcf.Support
                 return new TypeFormat(ParameterType.Array, null);
             }
 
+            //it's a Nullable<T> so treat it as T - we'll handle making it not-required later
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                return MapSwaggerType(type.GenericTypeArguments[0], definitions);
+            }
+
             //it's a complex type, so we'll need to map it later
             if (definitions != null && !definitions.Contains(type))
             {


### PR DESCRIPTION
This improves the results when using, e.g., bool?, or similar in models by treating them as their underlying type but optional rather than including the CLR nullable type in the output explicitly, which is meaningless to the caller.