### PR TITLE
Add example to property

### DIFF
--- a/src/SwaggerWcf/Attributes/SwaggerWcfPropertyAttribute.cs
+++ b/src/SwaggerWcf/Attributes/SwaggerWcfPropertyAttribute.cs
@@ -48,6 +48,11 @@ namespace SwaggerWcf.Attributes
         public string Default { get; set; }
 
         /// <summary>
+        ///     Illustrate what the value is supposed to be like.
+        /// </summary>
+        public object Example { get; set; }
+
+        /// <summary>
         ///     Maximum allowed value, as modified by ExclusiveMaximum.
         ///     Must be a valid JSON number, and storable as a decimal.
         /// </summary>

--- a/src/SwaggerWcf/Models/DefinitionProperty.cs
+++ b/src/SwaggerWcf/Models/DefinitionProperty.cs
@@ -31,6 +31,8 @@ namespace SwaggerWcf.Models
 
         public string Default { get; set; }
 
+        public object Example { get; set; }
+
         public decimal Maximum { get; set; }
 
         public bool ExclusiveMaximum { get; set; }
@@ -91,6 +93,21 @@ namespace SwaggerWcf.Models
                 {
                     writer.WritePropertyName("default");
                     writer.WriteValue(Default);
+                }
+                if (Example!=null)
+                {
+                    writer.WritePropertyName("example");
+                    if (Example.GetType().IsArray)
+                    {
+                        writer.WriteStartArray();
+                        foreach (var value in (object[])Example)
+                        {
+                            writer.WriteValue(value);
+                        }
+                        writer.WriteEndArray();
+                    }
+                    else
+                        writer.WriteValue(Example);
                 }
                 if (Maximum != decimal.MaxValue)
                 {

--- a/src/SwaggerWcf/Support/DefinitionsBuilder.cs
+++ b/src/SwaggerWcf/Support/DefinitionsBuilder.cs
@@ -308,6 +308,7 @@ namespace SwaggerWcf.Support
             //ApplyIfValid(LastValidValue(attrs, a => a._AllowEmptyValue),  x => prop.AllowEmptyValue  = x.Value);
             //ApplyIfValid(LastValidValue(attrs, a => a._CollectionFormat), x => prop.CollectionFormat = x.Value);
             ApplyIfValid(LastValidValue(attrs, a => a.Default), x => prop.Default = x);
+            ApplyIfValid(LastValidValue(attrs, a => a.Example), x => prop.Example = x);
             ApplyIfValid(LastValidValue(attrs, a => a._Maximum), x => prop.Maximum = x.Value);
             ApplyIfValid(LastValidValue(attrs, a => a._ExclusiveMaximum), x => prop.ExclusiveMaximum = x.Value);
             ApplyIfValid(LastValidValue(attrs, a => a._Minimum), x => prop.Minimum = x.Value);


### PR DESCRIPTION
fixes #62 
works with primitive types and arrays of primitive types

```csharp

[DataMember]
[Description("Book Title")]
[SwaggerWcfProperty(Example = "Book Sample")]
public string Title { get; set; }

[DataMember]
[Description("Book Tags")]
[SwaggerWcfProperty(Example = new[] { "Book", "Sample" })]
public string[] Tags { get; set; }

```