### PR TITLE
Added generic SwaggerWcfEndpoint

### DIFF
--- a/src/SwaggerWcf/SwaggerWcf.csproj
+++ b/src/SwaggerWcf/SwaggerWcf.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Attributes\SwaggerWcfHeaderAttribute.cs" />
     <Compile Include="Attributes\SwaggerWcfPropertyAttribute.cs" />
     <Compile Include="Attributes\SwaggerWcfReturnTypeAttribute.cs" />
+    <Compile Include="SwaggerWcfEndpointBase.cs" />
     <Compile Include="Models\SecurityAuthorization.cs" />
     <Compile Include="Models\DefinitionSchema.cs" />
     <Compile Include="Models\DefinitionProperty.cs" />
@@ -108,6 +109,7 @@
     <Compile Include="Support\ServiceBuilder.cs" />
     <Compile Include="Support\StaticContent.cs" />
     <Compile Include="Support\TypeExtensions.cs" />
+    <Compile Include="SwaggerWcfEndpointGeneric.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="www\swagger-ui.zip" />

--- a/src/SwaggerWcf/SwaggerWcfEndpointBase.cs
+++ b/src/SwaggerWcf/SwaggerWcfEndpointBase.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.ServiceModel.Web;
+
+namespace SwaggerWcf
+{
+    public abstract class SwaggerWcfEndpointBase : ISwaggerWcfEndpoint
+    {
+        public static void SetCustomZip(Stream customSwaggerUiZipStream)
+        {
+            if (customSwaggerUiZipStream != null)
+                Support.StaticContent.SetArchiveCustom(customSwaggerUiZipStream);
+        }
+
+        public static void SetCustomGetFile(GetFileCustomDelegate getFileCustom)
+        {
+            Support.StaticContent.GetFileCustom = getFileCustom;
+        }
+
+        public abstract Stream GetSwaggerFile(); 
+
+        public Stream StaticContent(string content)
+        {
+            WebOperationContext woc = WebOperationContext.Current;
+
+            if (woc == null)
+                return Stream.Null;
+
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                string swaggerUrl = woc.IncomingRequest.UriTemplateMatch.BaseUri.LocalPath + "/swagger.json";
+                woc.OutgoingResponse.StatusCode = HttpStatusCode.Redirect;
+                woc.OutgoingResponse.Location = "index.html?url=" + swaggerUrl;
+                return null;
+            }
+
+            string filename = content.Contains("?")
+                ? content.Substring(0, content.IndexOf("?", StringComparison.Ordinal))
+                : content;
+
+            string contentType;
+            long contentLength;
+            Stream stream = Support.StaticContent.GetFile(filename, out contentType, out contentLength);
+
+            if (stream == Stream.Null)
+            {
+                woc.OutgoingResponse.StatusCode = HttpStatusCode.NotFound;
+                return null;
+            }
+
+            woc.OutgoingResponse.StatusCode = HttpStatusCode.OK;
+            woc.OutgoingResponse.ContentLength = contentLength;
+            woc.OutgoingResponse.ContentType = contentType;
+
+            return stream;
+        }
+    }
+}

--- a/src/SwaggerWcf/SwaggerWcfEndpointGeneric.cs
+++ b/src/SwaggerWcf/SwaggerWcfEndpointGeneric.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.IO;
+using System.ServiceModel.Web;
+using System.Text;
+using System.Threading;
+using SwaggerWcf.Models;
+using SwaggerWcf.Support;
+
+namespace SwaggerWcf
+{
+    public class SwaggerWcfEndpoint<TBusiness> : SwaggerWcfEndpointBase
+    {
+        private static int _initialized;
+        private static Service Service { get; set; }
+
+        public SwaggerWcfEndpoint()
+        {
+            Init();
+        }
+
+        private static void Init()
+        {
+            if (Interlocked.CompareExchange(ref _initialized, 1, 0) != 0)
+                return;
+
+            Service = ServiceBuilder.Build<TBusiness>();
+        }
+
+        public static void Configure(Info info, SecurityDefinitions securityDefinitions = null)
+        {
+            Init();
+            Service.Info = info;
+            Service.SecurityDefinitions = securityDefinitions;
+        }
+
+        public override Stream GetSwaggerFile()
+        {
+            WebOperationContext woc = WebOperationContext.Current;
+            if (woc != null)
+            {
+                //TODO: create a parameter in settings to configure this
+                woc.OutgoingResponse.Headers.Add("Access-Control-Allow-Origin", "*");
+                woc.OutgoingResponse.ContentType = "application/json";
+            }
+
+            return new MemoryStream(Encoding.UTF8.GetBytes(Serializer.Process(Service)));
+        }
+    }
+}


### PR DESCRIPTION
Added generic SwaggerWcfEndpoint and extracted logic to baseclass SwaggerWcfEndpointBase, ServiceBuilder can get paths from generic type.

Fixed #67 