### PR TITLE
Fix #98 - Support custom model names

### DIFF
--- a/src/SwaggerWcf.Test.Service/Data/Author.cs
+++ b/src/SwaggerWcf.Test.Service/Data/Author.cs
@@ -1,8 +1,10 @@
 ﻿using System.Runtime.Serialization;
+using SwaggerWcf.Attributes;
 
 namespace SwaggerWcf.Test.Service.Data
 {
     [DataContract]
+    [SwaggerWcfDefinition("author")]
     public class Author
     {
         [DataMember]

--- a/src/SwaggerWcf/Attributes/SwaggerWcfDefinitionAttribute.cs
+++ b/src/SwaggerWcf/Attributes/SwaggerWcfDefinitionAttribute.cs
@@ -20,6 +20,11 @@ namespace SwaggerWcf.Attributes
             ExternalDocsUrl = externalDocsUrl;
         }
 
+        public SwaggerWcfDefinitionAttribute(string modelName)
+        {
+            ModelName = modelName;
+        }
+
         /// <summary>
         ///     Description of the external documentation
         /// </summary>
@@ -29,5 +34,7 @@ namespace SwaggerWcf.Attributes
         ///     URL of the external documentation
         /// </summary>
         public string ExternalDocsUrl { get; set; }
+
+        public string ModelName { get; set; }
     }
 }

--- a/src/SwaggerWcf/Attributes/SwaggerWcfDefinitionAttribute.cs
+++ b/src/SwaggerWcf/Attributes/SwaggerWcfDefinitionAttribute.cs
@@ -9,6 +9,21 @@ namespace SwaggerWcf.Attributes
     public class SwaggerWcfDefinitionAttribute : Attribute
     {
         /// <summary>
+        ///     Description of the external documentation
+        /// </summary>
+        public string ExternalDocsDescription { get; set; }
+
+        /// <summary>
+        ///     URL of the external documentation
+        /// </summary>
+        public string ExternalDocsUrl { get; set; }
+
+        /// <summary>
+        /// Optional custom name for model. Model names default to class's fully qualified name
+        /// </summary>
+        public string ModelName { get; set; }
+
+        /// <summary>
         ///     Configures a description with more information
         /// </summary>
         /// <param name="externalDocsDescription">Description external docs description</param>
@@ -19,22 +34,5 @@ namespace SwaggerWcf.Attributes
             ExternalDocsDescription = externalDocsDescription;
             ExternalDocsUrl = externalDocsUrl;
         }
-
-        public SwaggerWcfDefinitionAttribute(string modelName)
-        {
-            ModelName = modelName;
-        }
-
-        /// <summary>
-        ///     Description of the external documentation
-        /// </summary>
-        public string ExternalDocsDescription { get; set; }
-
-        /// <summary>
-        ///     URL of the external documentation
-        /// </summary>
-        public string ExternalDocsUrl { get; set; }
-
-        public string ModelName { get; set; }
     }
 }

--- a/src/SwaggerWcf/Support/DefinitionsBuilder.cs
+++ b/src/SwaggerWcf/Support/DefinitionsBuilder.cs
@@ -52,13 +52,9 @@ namespace SwaggerWcf.Support
         private static Definition ConvertTypeToDefinition(Type definitionType, IList<string> hiddenTags,
                                                           Stack<Type> typesStack)
         {
-            var attr = definitionType.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
-            string name = (attr == null || string.IsNullOrWhiteSpace(attr.ModelName))
-                ? definitionType.FullName
-                : attr.ModelName;
             DefinitionSchema schema = new DefinitionSchema
             {
-                Name = name
+                Name = definitionType.GetModelName()
             };
 
             ProcessTypeAttributes(definitionType, schema);
@@ -88,14 +84,9 @@ namespace SwaggerWcf.Support
             {
                 Type t = GetEnumerableType(definitionType);
 
-                var attr2 = definitionType.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
-                string name2 = (attr2 == null || string.IsNullOrWhiteSpace(attr2.ModelName))
-                    ? t.FullName
-                    : attr2.ModelName;
-
                 if (t != null)
                 {
-                    schema.Ref = name2;
+                    schema.Ref = definitionType.GetModelName();
                     typesStack.Push(t);
                 }
             }
@@ -159,16 +150,11 @@ namespace SwaggerWcf.Support
                         //prop.TypeFormat = new TypeFormat(prop.TypeFormat.Type, HttpUtility.HtmlEncode(t.FullName));
                         prop.TypeFormat = new TypeFormat(prop.TypeFormat.Type, null);
 
-                        var attr = t.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
-                        string name = (attr == null || string.IsNullOrWhiteSpace(attr.ModelName))
-                            ? t.FullName
-                            : attr.ModelName;
-
                         TypeFormat st = Helpers.MapSwaggerType(t);
                         if (st.Type == ParameterType.Array || st.Type == ParameterType.Object)
                         {
                             prop.Items.TypeFormat = new TypeFormat(ParameterType.Unknown, null);
-                            prop.Items.Ref = name;
+                            prop.Items.Ref = t.GetModelName();
                         }
                         else
                         {
@@ -227,7 +213,7 @@ namespace SwaggerWcf.Support
 
             // Special case - if it came out required, but we unwrapped a null-able type,
             // then it's necessarily not required.  Ideally this would only set the default,
-            // but we can't tell the difference between an explicit delaration of
+            // but we can't tell the difference between an explicit declaration of
             // IsRequired =false on the DataMember attribute and no declaration at all.
             if (prop.Required && propertyInfo.PropertyType.IsGenericType &&
                 propertyInfo.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
@@ -245,12 +231,7 @@ namespace SwaggerWcf.Support
             {
                 typesStack.Push(propertyInfo.PropertyType);
 
-                var attr = propertyInfo.PropertyType.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
-                string refName = (attr == null || string.IsNullOrWhiteSpace(attr.ModelName))
-                    ? propertyInfo.PropertyType.FullName
-                    : attr.ModelName;
-
-                prop.Ref = refName;
+                prop.Ref = propertyInfo.PropertyType.GetModelName();
 
                 return prop;
             }

--- a/src/SwaggerWcf/Support/DefinitionsBuilder.cs
+++ b/src/SwaggerWcf/Support/DefinitionsBuilder.cs
@@ -52,9 +52,13 @@ namespace SwaggerWcf.Support
         private static Definition ConvertTypeToDefinition(Type definitionType, IList<string> hiddenTags,
                                                           Stack<Type> typesStack)
         {
+            var attr = definitionType.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
+            string name = (attr == null || string.IsNullOrWhiteSpace(attr.ModelName))
+                ? definitionType.FullName
+                : attr.ModelName;
             DefinitionSchema schema = new DefinitionSchema
             {
-                Name = definitionType.FullName
+                Name = name
             };
 
             ProcessTypeAttributes(definitionType, schema);
@@ -84,9 +88,14 @@ namespace SwaggerWcf.Support
             {
                 Type t = GetEnumerableType(definitionType);
 
+                var attr2 = definitionType.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
+                string name2 = (attr2 == null || string.IsNullOrWhiteSpace(attr2.ModelName))
+                    ? t.FullName
+                    : attr2.ModelName;
+
                 if (t != null)
                 {
-                    schema.Ref = t.FullName;
+                    schema.Ref = name2;
                     typesStack.Push(t);
                 }
             }
@@ -120,6 +129,9 @@ namespace SwaggerWcf.Support
                         Url = definitionAttr.ExternalDocsUrl
                     };
                 }
+
+                if (!string.IsNullOrWhiteSpace(definitionAttr.ModelName))
+                    schema.Name = definitionAttr.ModelName;
             }
         }
 
@@ -147,11 +159,16 @@ namespace SwaggerWcf.Support
                         //prop.TypeFormat = new TypeFormat(prop.TypeFormat.Type, HttpUtility.HtmlEncode(t.FullName));
                         prop.TypeFormat = new TypeFormat(prop.TypeFormat.Type, null);
 
+                        var attr = t.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
+                        string name = (attr == null || string.IsNullOrWhiteSpace(attr.ModelName))
+                            ? t.FullName
+                            : attr.ModelName;
+
                         TypeFormat st = Helpers.MapSwaggerType(t);
                         if (st.Type == ParameterType.Array || st.Type == ParameterType.Object)
                         {
                             prop.Items.TypeFormat = new TypeFormat(ParameterType.Unknown, null);
-                            prop.Items.Ref = t.FullName;
+                            prop.Items.Ref = name;
                         }
                         else
                         {
@@ -228,7 +245,12 @@ namespace SwaggerWcf.Support
             {
                 typesStack.Push(propertyInfo.PropertyType);
 
-                prop.Ref = propertyInfo.PropertyType.FullName;
+                var attr = propertyInfo.PropertyType.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
+                string refName = (attr == null || string.IsNullOrWhiteSpace(attr.ModelName))
+                    ? propertyInfo.PropertyType.FullName
+                    : attr.ModelName;
+
+                prop.Ref = refName;
 
                 return prop;
             }

--- a/src/SwaggerWcf/Support/Helpers.cs
+++ b/src/SwaggerWcf/Support/Helpers.cs
@@ -3,9 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization;
 using System.Web;
-using SwaggerWcf.Attributes;
 using SwaggerWcf.Configuration;
 using SwaggerWcf.Models;
 
@@ -120,11 +118,7 @@ namespace SwaggerWcf.Support
                 definitions.Add(type);
             }
 
-            var attr = type.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
-            string name = (attr == null || string.IsNullOrWhiteSpace(attr.ModelName))
-                ? type.FullName
-                : attr.ModelName;
-            return new TypeFormat(ParameterType.Object, HttpUtility.HtmlEncode(name));
+            return new TypeFormat(ParameterType.Object, HttpUtility.HtmlEncode(type.GetModelName()));
         }
 
         private static string BuildTypeString(string typeName, string defaultNote = null, string typeNote = null)

--- a/src/SwaggerWcf/Support/Helpers.cs
+++ b/src/SwaggerWcf/Support/Helpers.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Web;
+using SwaggerWcf.Attributes;
 using SwaggerWcf.Configuration;
 using SwaggerWcf.Models;
 
@@ -94,7 +95,7 @@ namespace SwaggerWcf.Support
             {
                 return new TypeFormat(ParameterType.String, "enum");
             }
-            
+
             //it's a collection/array, so it will use the swagger "container" syntax
             if (type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>)))
             {
@@ -118,7 +119,12 @@ namespace SwaggerWcf.Support
             {
                 definitions.Add(type);
             }
-            return new TypeFormat(ParameterType.Object, HttpUtility.HtmlEncode(type.FullName));
+
+            var attr = type.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
+            string name = (attr == null || string.IsNullOrWhiteSpace(attr.ModelName))
+                ? type.FullName
+                : attr.ModelName;
+            return new TypeFormat(ParameterType.Object, HttpUtility.HtmlEncode(name));
         }
 
         private static string BuildTypeString(string typeName, string defaultNote = null, string typeNote = null)
@@ -153,7 +159,7 @@ namespace SwaggerWcf.Support
 
             return prop.GetValue(attr) as T1;
         }
-        
+
         public static bool GetCustomAttributeValue<T>(MethodInfo method, string propertyName, bool defaultVal = false)
             where T : Attribute
         {
@@ -169,7 +175,7 @@ namespace SwaggerWcf.Support
                 return defaultVal;
             }
 
-            return (bool) prop.GetValue(attr);
+            return (bool)prop.GetValue(attr);
         }
 
         internal static TypeFormat MapElementType(Type type, List<Type> definitions)

--- a/src/SwaggerWcf/Support/Mapper.cs
+++ b/src/SwaggerWcf/Support/Mapper.cs
@@ -401,12 +401,6 @@ namespace SwaggerWcf.Support
                 if (typeFormat.Type == ParameterType.Array)
                 {
                     Type t = paramType.GetElementType() ?? GetEnumerableType(paramType);
-
-                    var attr2 = t.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
-                    string refName2 = (attr2 == null || string.IsNullOrWhiteSpace(attr2.ModelName))
-                        ? t.FullName
-                        : attr2.ModelName;
-
                     ParameterPrimitive arrayParam = new ParameterPrimitive
                     {
                         Name = name,
@@ -418,7 +412,7 @@ namespace SwaggerWcf.Support
                         {
                             Items = new ParameterSchema
                             {
-                                SchemaRef = refName2
+                                SchemaRef = t.GetModelName()
                             }
                         },
                         CollectionFormat = CollectionFormat.Csv
@@ -451,13 +445,8 @@ namespace SwaggerWcf.Support
                     definitionsTypesList.Add(paramType);
                 }
 
-                var attr = paramType.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
-                string refName = (attr == null || string.IsNullOrWhiteSpace(attr.ModelName))
-                    ? paramType.FullName
-                    : attr.ModelName;
-
                 typeFormat = new TypeFormat(ParameterType.Object,
-                                            HttpUtility.HtmlEncode(refName));
+                                             HttpUtility.HtmlEncode(paramType.GetModelName()));
 
                 return new ParameterSchema
                 {
@@ -639,15 +628,10 @@ namespace SwaggerWcf.Support
             }
             TypeFormat typeFormat = new TypeFormat(ParameterType.Unknown, null);
 
-            var attr = returnType.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
-            string refName = (attr == null || string.IsNullOrWhiteSpace(attr.ModelName))
-                ? returnType.FullName
-                : attr.ModelName;
-
             return new Schema
             {
                 TypeFormat = typeFormat,
-                Ref = HttpUtility.HtmlEncode(refName)
+                Ref = HttpUtility.HtmlEncode(returnType.GetModelName())
             };
         }
 
@@ -688,14 +672,10 @@ namespace SwaggerWcf.Support
                     if (t == null)
                         return null;
                     definitionsTypesList.Add(t);
-                    var attr = t.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
-                    string refName = (attr == null || string.IsNullOrWhiteSpace(attr.ModelName))
-                        ? t.FullName
-                        : attr.ModelName;
                     return new Schema
                     {
                         TypeFormat = typeFormat,
-                        Ref = HttpUtility.HtmlEncode(refName)
+                        Ref = HttpUtility.HtmlEncode(t.GetModelName())
                     };
                 default:
                     definitionsTypesList.Add(type);

--- a/src/SwaggerWcf/Support/Mapper.cs
+++ b/src/SwaggerWcf/Support/Mapper.cs
@@ -50,7 +50,7 @@ namespace SwaggerWcf.Support
 
                 serviceType = allTypes.Except(allTypes.Select(type => type.BaseType)).Single();
 
-                types = new List<Type> {markedType};
+                types = new List<Type> { markedType };
             }
             else
             {
@@ -401,6 +401,12 @@ namespace SwaggerWcf.Support
                 if (typeFormat.Type == ParameterType.Array)
                 {
                     Type t = paramType.GetElementType() ?? GetEnumerableType(paramType);
+
+                    var attr2 = t.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
+                    string refName2 = (attr2 == null || string.IsNullOrWhiteSpace(attr2.ModelName))
+                        ? t.FullName
+                        : attr2.ModelName;
+
                     ParameterPrimitive arrayParam = new ParameterPrimitive
                     {
                         Name = name,
@@ -412,7 +418,7 @@ namespace SwaggerWcf.Support
                         {
                             Items = new ParameterSchema
                             {
-                                SchemaRef = t.FullName
+                                SchemaRef = refName2
                             }
                         },
                         CollectionFormat = CollectionFormat.Csv
@@ -444,8 +450,14 @@ namespace SwaggerWcf.Support
                 {
                     definitionsTypesList.Add(paramType);
                 }
+
+                var attr = paramType.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
+                string refName = (attr == null || string.IsNullOrWhiteSpace(attr.ModelName))
+                    ? paramType.FullName
+                    : attr.ModelName;
+
                 typeFormat = new TypeFormat(ParameterType.Object,
-                                            HttpUtility.HtmlEncode(paramType.FullName));
+                                            HttpUtility.HtmlEncode(refName));
 
                 return new ParameterSchema
                 {
@@ -627,10 +639,15 @@ namespace SwaggerWcf.Support
             }
             TypeFormat typeFormat = new TypeFormat(ParameterType.Unknown, null);
 
+            var attr = returnType.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
+            string refName = (attr == null || string.IsNullOrWhiteSpace(attr.ModelName))
+                ? returnType.FullName
+                : attr.ModelName;
+
             return new Schema
             {
                 TypeFormat = typeFormat,
-                Ref = HttpUtility.HtmlEncode(returnType.FullName)
+                Ref = HttpUtility.HtmlEncode(refName)
             };
         }
 
@@ -671,10 +688,14 @@ namespace SwaggerWcf.Support
                     if (t == null)
                         return null;
                     definitionsTypesList.Add(t);
+                    var attr = t.GetCustomAttribute<SwaggerWcfDefinitionAttribute>();
+                    string refName = (attr == null || string.IsNullOrWhiteSpace(attr.ModelName))
+                        ? t.FullName
+                        : attr.ModelName;
                     return new Schema
                     {
                         TypeFormat = typeFormat,
-                        Ref = HttpUtility.HtmlEncode(t.FullName)
+                        Ref = HttpUtility.HtmlEncode(refName)
                     };
                 default:
                     definitionsTypesList.Add(type);

--- a/src/SwaggerWcf/Support/TypeExtensions.cs
+++ b/src/SwaggerWcf/Support/TypeExtensions.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using SwaggerWcf.Attributes;
+using System;
 using System.Linq;
+using System.Reflection;
 
 namespace SwaggerWcf.Support
 {
@@ -15,5 +17,8 @@ namespace SwaggerWcf.Support
 
             return genericArguments.Any() ? genericArguments[0] : null;
         }
+
+        public static string GetModelName(this Type type) =>
+            type.GetCustomAttribute<SwaggerWcfDefinitionAttribute>()?.ModelName ?? type.FullName;
     }
 }


### PR DESCRIPTION
A fix for issue #98 .

Obviously, I didn't put much effort in understanding the whole design and did some duplication. However, it works and allows users to hide their code structure (namespace, class name) from others.

Custom model name is optional and the default model name is the same as before - class's FullName. 

```c#
[SwaggerWcfDefinition(ModelName = "author")]
public class Author { }
```