### PR TITLE
Adding a way for make visible Tag with different api-docs URL.

### DIFF
--- a/src/SwaggerWcf/Support/ServiceBuilder.cs
+++ b/src/SwaggerWcf/Support/ServiceBuilder.cs
@@ -13,9 +13,9 @@ namespace SwaggerWcf.Support
 {
     internal class ServiceBuilder
     {
-        public static Service Build()
+        public static Service Build(List<string> visibleTags_RoutePrefix)
         {
-            Service service = BuildService();
+            Service service = BuildService(visibleTags_RoutePrefix);
 
             return service;
         }
@@ -27,7 +27,7 @@ namespace SwaggerWcf.Support
             return service;
         }
 
-        private static Service BuildService()
+        private static Service BuildService(List<string> visibleTags_RoutePrefix)
         {
             const string sectionName = "swaggerwcf";
             SwaggerWcfSection config =
@@ -37,6 +37,7 @@ namespace SwaggerWcf.Support
             Service service = new Service();
             List<string> hiddenTags = GetHiddenTags(config);
             List<string> visibleTags = GetVisibleTags(config);
+            if (visibleTags_RoutePrefix != null) visibleTags.AddRange(visibleTags_RoutePrefix);
             IReadOnlyDictionary<string, string> settings = GetSettings(config);
 
             ProcessSettings(service, settings);

--- a/src/SwaggerWcf/SwaggerWcfEndpoint.cs
+++ b/src/SwaggerWcf/SwaggerWcfEndpoint.cs
@@ -17,7 +17,11 @@ namespace SwaggerWcf
     public class SwaggerWcfEndpoint : SwaggerWcfEndpointBase
     {
         private static Service Service { get; set; }
-        private static int _initialized;
+        private static String _lastLocalPath = "";
+        private static Dictionary<string, List<string>> _routePrefix_VisibleTag;
+        private static Info _info;
+        private static SecurityDefinitions _securityDefinitions;
+
 
         public SwaggerWcfEndpoint()
         {
@@ -26,17 +30,77 @@ namespace SwaggerWcf
 
         private static void Init()
         {
-            if (Interlocked.CompareExchange(ref _initialized, 1, 0) != 0)
+
+            String localPath = GetLocalPath();
+
+            //Only StaticContent
+            try
+            {
+                if (!System.ServiceModel.Web.WebOperationContext.Current.IncomingRequest.UriTemplateMatch.Data.Equals("StaticContent"))
+                    return;
+            }
+            catch { }
+
+            if (localPath != "" &&_lastLocalPath.Equals(localPath))
                 return;
 
-            Service = ServiceBuilder.Build();
+            _lastLocalPath = localPath;
+
+            Service = ServiceBuilder.Build(Get_VisibleTags(localPath));
+
+            Service.Info = _info;
+            Service.SecurityDefinitions = _securityDefinitions;            
+        }
+
+        private static string GetLocalPath()
+        {
+            String localPath = "";
+
+            try
+            {
+                localPath = System.ServiceModel.Web.WebOperationContext.Current.IncomingRequest.UriTemplateMatch.BaseUri.LocalPath;
+            }
+            catch { }
+
+            return localPath;
+        }
+     
+        public static void Add_VisibleTag(String routePrefix, String tagName)
+        {
+            if (_routePrefix_VisibleTag == null)
+                _routePrefix_VisibleTag = new Dictionary<string, List<string>>();
+
+            if (!routePrefix.StartsWith("/"))
+                routePrefix = "/" + routePrefix;
+
+            if (routePrefix.EndsWith("/"))
+                routePrefix = routePrefix.Substring(routePrefix.Length - 1);
+
+            if (_routePrefix_VisibleTag.TryGetValue(routePrefix, out List<string> visibleTags) == false)
+            {
+                visibleTags = new List<string>();
+                _routePrefix_VisibleTag.Add(routePrefix, visibleTags);
+            }
+
+            visibleTags.Add(tagName);
+        }
+
+        private static List<string> Get_VisibleTags(String routePrefix)
+        {
+            if (_routePrefix_VisibleTag == null)
+                return null;
+
+            _routePrefix_VisibleTag.TryGetValue(routePrefix, out List<string> visibleTags);
+
+            return visibleTags;
         }
 
         public static void Configure(Info info, SecurityDefinitions securityDefinitions = null)
         {
+            _info = info;
+            _securityDefinitions = securityDefinitions;
+
             Init();
-            Service.Info = info;
-            Service.SecurityDefinitions = securityDefinitions;
         }
 
         public override Stream GetSwaggerFile()


### PR DESCRIPTION
Adding a way for make visible Tag with different api-docs URL.

A suggestion for #100 

By example:

> 	Routing.RouteTable.Routes.Add(new ServiceRoute("api-docs", new WebServiceHostFactory(), typeof(SwaggerWcfEndpoint)));
> 	Routing.RouteTable.Routes.Add(new ServiceRoute("api-docs2", new WebServiceHostFactory(), typeof(SwaggerWcfEndpoint)));
> 
> 	SwaggerWcfEndpoint.Add_VisibleTag("api-docs", "Service_1");
> 	SwaggerWcfEndpoint.Add_VisibleTag("api-docs2", "Service_2");

I'm not sure I'm doing it by the best way, but it's working.

Not sure about your standard of naming function and vars, hope it's fine.