### PR TITLE
Stop HTML encoding descriptions

### DIFF
--- a/src/SwaggerWcf/Support/Mapper.cs
+++ b/src/SwaggerWcf/Support/Mapper.cs
@@ -194,7 +194,7 @@ namespace SwaggerWcf.Support
                 {
                     externalDocs = new ExternalDocumentation
                     {
-                        Description = HttpUtility.HtmlEncode(externalDocsDescription),
+                        Description = externalDocsDescription,
                         Url = HttpUtility.HtmlEncode(externalDocsUrl)
                     };
                 }
@@ -208,7 +208,7 @@ namespace SwaggerWcf.Support
                 {
                     Id = httpMethod.ToLowerInvariant(),
                     Summary = summary,
-                    Description = HttpUtility.HtmlEncode(description),
+                    Description = description,
                     Tags =
                         methodTags.Where(t => !t.HideFromSpec).Select(t => HttpUtility.HtmlEncode(t.TagName)).ToList(),
                     Consumes = new List<string>(GetConsumes(implementation, declaration)),


### PR DESCRIPTION
Not HTML encoding the text allows the HTML special characters such as `"` appear properly in markdown text.

For example, the following description is currently encoded:

```markdown
This is some JSON ` { &quot;number&quot;: 12 }`
```