### PR TITLE
Add way to extend operation uri with the endpoint (fix #119).

### DIFF
--- a/src/SwaggerWcf/Attributes/SwaggerWcfPathAttribute.cs
+++ b/src/SwaggerWcf/Attributes/SwaggerWcfPathAttribute.cs
@@ -19,7 +19,8 @@ namespace SwaggerWcf.Attributes
         /// <param name="deprecated">Path deprecated (defaults to false)</param>
         public SwaggerWcfPathAttribute(string summary = null, string description = null, string operationId = null,
                                        string externalDocsDescription = null,
-                                       string externalDocsUrl = null, bool deprecated = false)
+                                       string externalDocsUrl = null, bool deprecated = false,
+                                       string operationPath = null)
         {
             Summary = summary;
             Description = description;
@@ -27,6 +28,7 @@ namespace SwaggerWcf.Attributes
             ExternalDocsDescription = externalDocsDescription;
             ExternalDocsUrl = externalDocsUrl;
             Deprecated = deprecated;
+            OperationPath = operationPath;
         }
 
         /// <summary>
@@ -58,5 +60,10 @@ namespace SwaggerWcf.Attributes
         ///     Path deprecated
         /// </summary>
         public bool Deprecated { get; set; }
+
+        /// <summary>
+        ///     Operation path, extends service path
+        /// </summary>
+        public string OperationPath { get; set; }
     }
 }

--- a/src/SwaggerWcf/Support/Mapper.cs
+++ b/src/SwaggerWcf/Support/Mapper.cs
@@ -93,13 +93,7 @@ namespace SwaggerWcf.Support
 
         private Path GetPath(string basePath, string pathUrl, List<Path> paths)
         {
-            string id = basePath;
-            if (basePath.EndsWith("/") && pathUrl.StartsWith("/"))
-                id += pathUrl.Substring(1);
-            else if (!basePath.EndsWith("/") && !string.IsNullOrWhiteSpace(pathUrl) && !pathUrl.StartsWith("/"))
-                id += "/" + pathUrl;
-            else
-                id += pathUrl;
+            string id = ConcatPaths(basePath, pathUrl);
 
             Path path = paths.FirstOrDefault(p => p.Id == id);
             if (path == null)
@@ -112,6 +106,18 @@ namespace SwaggerWcf.Support
                 paths.Add(path);
             }
 
+            return path;
+        }
+
+        private static string ConcatPaths(string basePath, string pathUrl)
+        {
+            string path = basePath;
+            if (basePath.EndsWith("/") && pathUrl.StartsWith("/"))
+                path += pathUrl.Substring(1);
+            else if (!basePath.EndsWith("/") && !string.IsNullOrWhiteSpace(pathUrl) && !pathUrl.StartsWith("/"))
+                path += "/" + pathUrl;
+            else
+                path += pathUrl;
             return path;
         }
 
@@ -203,6 +209,14 @@ namespace SwaggerWcf.Support
                     Helpers.GetCustomAttributeValue<SwaggerWcfPathAttribute>(implementation, "Deprecated");
                 if (!deprecated)
                     deprecated = Helpers.GetCustomAttributeValue<SwaggerWcfPathAttribute>(declaration, "Deprecated");
+
+                string operationPath =
+                    Helpers.GetCustomAttributeValue<string, SwaggerWcfPathAttribute>(implementation, "OperationPath") ??
+                    Helpers.GetCustomAttributeValue<string, SwaggerWcfPathAttribute>(declaration, "OperationPath");
+                if (!string.IsNullOrWhiteSpace(operationPath))
+                {
+                    uriTemplate = ConcatPaths(operationPath, uriTemplate);
+                }
 
                 PathAction operation = new PathAction
                 {


### PR DESCRIPTION
Hi,

I've forked the project and make a slight change which will allow to support the case described in #119 . `SwaggerWcfPath` attribute now has additional property and the final operation URL concatenates from `SwaggerWcf` attribute value, this property, and operations. By using this one can specify different endpoints in the implementation. Consider following third-party interfaces and their implementation:

```
public interface IFooService
{
    void Foo();
}
```

```
public interface IBarService
{
    void Bar();
}
```

```
[SwaggerWcf("api")]
public class Service : IFooService, IBarService
{
    [SwaggerWcfPath(OperationPath = "foo")]
    public void Foo() {}
    
    [SwaggerWcfPath(OperationPath = "bar")]
    public void Bar() {}
}
```

Then these operations will be correctly displayed and can be successfully triggered via Swagger UI using following URLs: `api/foo/foo` and `api/bar/bar`.

If required, I'll also change test application to demonstrate this case.

Thank you.