### PR TITLE
Fix Task return type, treat it as void.

### DIFF
--- a/src/SwaggerWcf/Support/Mapper.cs
+++ b/src/SwaggerWcf/Support/Mapper.cs
@@ -697,7 +697,7 @@ namespace SwaggerWcf.Support
 
         private Schema BuildSchema(Type type, MethodInfo implementation, MethodInfo declaration, bool wrappedResponse, IList<Type> definitionsTypesList)
         {
-            if (type == typeof(void))
+            if (type == typeof(void) || type == typeof(Task))
                 return null;
 
             if (type.BaseType == typeof(Task))


### PR DESCRIPTION
Hi,

Currently operations with `Task` return type are not really supported. SwaggerWcf processes them fine, but ends up generating json which contains a lot of definitions for `Task`-related BCL classes (like `Task` itself, `AggregatedException`, `SafeWaitHandle` etc.) and that hangs Swagger UI eventually.

The point is that `Task` type for asynchronous methods can be treated as `void` for synchronous ones.