### PR TITLE
Wrong query parameter names are used for operation call

### DIFF
--- a/src/SwaggerWcf.Test.Service/IStore.cs
+++ b/src/SwaggerWcf.Test.Service/IStore.cs
@@ -21,9 +21,9 @@ namespace SwaggerWcf.Test.Service
         Book CreateBook([SwaggerWcfParameter(Description = "Book to be created, the id will be replaced")] Book value);
 
         [SwaggerWcfPath("Get books", "Retrieve all books from the store")]
-        [WebGet(UriTemplate = "/books?filter={filter}", BodyStyle = WebMessageBodyStyle.Bare)]
+        [WebGet(UriTemplate = "/books?filter={filterText}", BodyStyle = WebMessageBodyStyle.Bare)]
         [OperationContract]
-        Book[] ReadBooks(string filter = null);
+        Book[] ReadBooks(string filterText = null);
 
         [SwaggerWcfPath("Get book", "Retrieve a book from the store using its id")]
         [WebGet(UriTemplate = "/books/{id}", BodyStyle = WebMessageBodyStyle.Bare, RequestFormat = WebMessageFormat.Json,

--- a/src/SwaggerWcf.Test.Service/Store.svc.cs
+++ b/src/SwaggerWcf.Test.Service/Store.svc.cs
@@ -78,7 +78,7 @@ namespace SwaggerWcf.Test.Service
         [SwaggerWcfTag("Books")]
         [SwaggerWcfResponse(HttpStatusCode.OK, "Book found, value in the response body")]
         [SwaggerWcfResponse(HttpStatusCode.NoContent, "No books", true)]
-        public Book[] ReadBooks(string filter = null)
+        public Book[] ReadBooks(string filterText = null)
         {
             WebOperationContext woc = WebOperationContext.Current;
 
@@ -88,7 +88,9 @@ namespace SwaggerWcf.Test.Service
             if (Store.Books.Any())
             {
                 woc.OutgoingResponse.StatusCode = HttpStatusCode.OK;
-                return Store.Books.ToArray();
+                return string.IsNullOrEmpty(filterText)
+                    ? Store.Books.ToArray()
+                    : Store.Books.Where(b => b.Author.Name.Contains(filterText) || b.Title.Contains(filterText)).ToArray();
             }
 
             woc.OutgoingResponse.StatusCode = HttpStatusCode.NoContent;

--- a/src/SwaggerWcf/Support/Mapper.cs
+++ b/src/SwaggerWcf/Support/Mapper.cs
@@ -299,7 +299,7 @@ namespace SwaggerWcf.Support
                     TypeFormat typeFormat = Helpers.MapSwaggerType(type, definitionsTypesList);
 
                     operation.Parameters.Add(GetParameter(typeFormat, declaration, implementation, parameter, settings, uriTemplate, wrappedRequest,
-                                                          definitionsTypesList));
+                                                          definitionsTypesList, inType));
                 }
                 if (wrappedRequest)
                 {
@@ -367,13 +367,20 @@ namespace SwaggerWcf.Support
                    (wi.BodyStyle == WebMessageBodyStyle.Wrapped || wi.BodyStyle == WebMessageBodyStyle.WrappedResponse);
         }
 
-        private ParameterBase GetParameter(TypeFormat typeFormat, MethodInfo declaration, MethodInfo implementation, ParameterInfo parameter, SwaggerWcfParameterAttribute settings, string uriTemplate, bool wrappedRequest, IList<Type> definitionsTypesList)
+        private ParameterBase GetParameter(TypeFormat typeFormat,
+                                           MethodInfo declaration,
+                                           MethodInfo implementation,
+                                           ParameterInfo parameter,
+                                           SwaggerWcfParameterAttribute settings,
+                                           string uriTemplate,
+                                           bool wrappedRequest,
+                                           IList<Type> definitionsTypesList,
+                                           InType inType)
         {
             string description = settings?.Description;
             bool required = settings != null && settings.Required;
             string name = parameter.Name;
 
-            InType inType = GetInType(uriTemplate, parameter.Name);
             if (inType == InType.Path)
                 required = true;
 

--- a/src/SwaggerWcf/Support/Mapper.cs
+++ b/src/SwaggerWcf/Support/Mapper.cs
@@ -379,7 +379,7 @@ namespace SwaggerWcf.Support
         {
             string description = settings?.Description;
             bool required = settings != null && settings.Required;
-            string name = parameter.Name;
+            string name = inType == InType.Query ? ResolveParameterNameFromUri(uriTemplate, parameter) : parameter.Name;
 
             if (inType == InType.Path)
                 required = true;
@@ -523,9 +523,29 @@ namespace SwaggerWcf.Support
             return param;
         }
 
+        private static string ResolveParameterNameFromUri(string uriTemplate, ParameterInfo parameter)
+        {
+            int questionMarkPosition = uriTemplate.IndexOf("?", StringComparison.Ordinal);
+            var uriParameters = HttpUtility.ParseQueryString(uriTemplate.Substring(questionMarkPosition + 1));
+
+            string parameterTemplate = GetParameterNameTemplate(parameter.Name);
+
+            var resolvedParameter = uriParameters
+                .AllKeys
+                .Select(k => new { Name = k, Template = uriParameters.Get(k) })
+                .FirstOrDefault(p => p.Template.Equals(parameterTemplate, StringComparison.Ordinal));
+
+            return resolvedParameter != null ? resolvedParameter.Name : parameter.Name;
+        }
+
+        private static string GetParameterNameTemplate(string parameterName)
+        {
+            return string.Format("{{{0}}}", parameterName);
+        }
+
         private InType GetInType(string uriTemplate, string parameterName)
         {
-            Regex reg = new Regex(@"\{" + parameterName + @"\}");
+            Regex reg = new Regex(GetParameterNameTemplate(parameterName));
             Regex regWithDefaultValue = new Regex(@"\{" + parameterName + @"=[a-zA-Z0-9]+\}");
             if (!reg.Match(uriTemplate).Success && !regWithDefaultValue.Match(uriTemplate).Success)
                 return InType.Body;

--- a/src/SwaggerWcf/Support/Mapper.cs
+++ b/src/SwaggerWcf/Support/Mapper.cs
@@ -372,10 +372,6 @@ namespace SwaggerWcf.Support
             string description = settings?.Description;
             bool required = settings != null && settings.Required;
             string name = parameter.Name;
-            DataMemberAttribute dataMemberAttribute = parameter.GetCustomAttribute<DataMemberAttribute>();
-
-            if (!string.IsNullOrEmpty(dataMemberAttribute?.Name))
-                name = dataMemberAttribute.Name;
 
             InType inType = GetInType(uriTemplate, parameter.Name);
             if (inType == InType.Path)


### PR DESCRIPTION
Hi,

Let's say we have following operation:

```
[WebGet(UriTemplate = "/books?filter={filterText}", BodyStyle = WebMessageBodyStyle.Bare)]
[OperationContract]
Book[] ReadBooks(string filterText = null);
```

Notice, that parameter name in URI does not match parameter name in the contract. This is absolutely legal situation. Now, generated swagger.json for this parameter looks like this:

```
"parameters": [
    {
        "name": "filterText",
        "in": "query",
        "type": "string"
    }
]
```

Parameter name in the contract is always used for calls. But instead, parameter name from URI should be used:

```
"parameters": [
    {
        "name": "filter",
        "in": "query",
        "type": "string"
    }
]
```