### PR TITLE
Attributes to provide API metadata

### DIFF
--- a/src/SwaggerWcf.Test.Service/Global.asax.cs
+++ b/src/SwaggerWcf.Test.Service/Global.asax.cs
@@ -18,6 +18,7 @@ namespace SwaggerWcf.Test.Service
             RouteTable.Routes.Add(new ServiceRoute("v1/rest", new WebServiceHostFactory(), typeof(BookStore)));
             RouteTable.Routes.Add(new ServiceRoute("api-docs", new WebServiceHostFactory(), typeof(SwaggerWcfEndpoint)));
 
+            /*
             var info = new Info
             {
                 Title = "Sample Service",
@@ -27,6 +28,7 @@ namespace SwaggerWcf.Test.Service
             };
 
             SwaggerWcfEndpoint.Configure(info);
+            */
         }
 
         private static List<string> FilterVisibleTags(string path, List<string> visibleTags)

--- a/src/SwaggerWcf.Test.Service/Store.svc.cs
+++ b/src/SwaggerWcf.Test.Service/Store.svc.cs
@@ -20,6 +20,10 @@ namespace SwaggerWcf.Test.Service
         Url = "http://github.com/abelsilva",
         Email = "no@e.mail"
     )]
+    [SwaggerWcfLicenseInfo(
+        name: "Apache License 2.0",
+        Url = "https://github.com/abelsilva/SwaggerWCF/blob/master/LICENSE"
+    )]
     public class BookStore : IStore
     {
         #region /books

--- a/src/SwaggerWcf.Test.Service/Store.svc.cs
+++ b/src/SwaggerWcf.Test.Service/Store.svc.cs
@@ -9,7 +9,17 @@ using SwaggerWcf.Test.Service.Data;
 namespace SwaggerWcf.Test.Service
 {
     [SwaggerWcf("/v1/rest")]
-    [SwaggerWcfServiceInfo("SampleService", "0.0.1")]
+    [SwaggerWcfServiceInfo(
+        title: "SampleService",
+        version: "0.0.1",
+        Description = "Sample Service to test SwaggerWCF",
+        TermsOfService = "Terms of Service"
+    )]
+    [SwaggerWcfContactInfo(
+        Name = "Abel Silva",
+        Url = "http://github.com/abelsilva",
+        Email = "no@e.mail"
+    )]
     public class BookStore : IStore
     {
         #region /books

--- a/src/SwaggerWcf.Test.Service/Store.svc.cs
+++ b/src/SwaggerWcf.Test.Service/Store.svc.cs
@@ -9,6 +9,7 @@ using SwaggerWcf.Test.Service.Data;
 namespace SwaggerWcf.Test.Service
 {
     [SwaggerWcf("/v1/rest")]
+    [SwaggerWcfServiceInfo("SampleService", "0.0.1")]
     public class BookStore : IStore
     {
         #region /books

--- a/src/SwaggerWcf.Test.Service/Web.config
+++ b/src/SwaggerWcf.Test.Service/Web.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0"?>
 <configuration>
+  <!--
   <configSections>
     <section name="swaggerwcf" type="SwaggerWcf.Configuration.SwaggerWcfSection, SwaggerWcf"/>
   </configSections>
@@ -20,6 +21,7 @@
       <setting name="InfoLicenseName" value="Apache License"/>
     </settings>
   </swaggerwcf>
+  -->
   <appSettings>
     <add key="aspnet:UseTaskFriendlySynchronizationContext" value="true"/>
   </appSettings>

--- a/src/SwaggerWcf/Attributes/SwaggerWcfAttribute.cs
+++ b/src/SwaggerWcf/Attributes/SwaggerWcfAttribute.cs
@@ -3,23 +3,32 @@
 namespace SwaggerWcf.Attributes
 {
     /// <summary>
-    ///     Attribute to enable a class or interface to be scanned by SwaggerWcf
+    /// Attribute to enable a class or interface to be scanned by SwaggerWcf
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
     public class SwaggerWcfAttribute : Attribute
     {
         /// <summary>
-        ///     Export this service on Swagger file
+        /// The base path on which the API is served, which is relative to the host. If it is not included,
+        /// the API is served directly under the host. The value MUST start with a leading slash (/). The
+        /// basePath does not support path templating.
+        /// </summary>
+        public string BasePath { get; set; }
+
+        /// <summary>
+        /// Export this service on Swagger file
+        /// </summary>
+        public SwaggerWcfAttribute()
+        {
+        }
+
+        /// <summary>
+        /// Export this service on Swagger file with base path of <paramref name="servicePath"/>
         /// </summary>
         /// <param name="servicePath">Service path</param>
         public SwaggerWcfAttribute(string servicePath)
         {
-            ServicePath = servicePath.StartsWith("/") ? servicePath : $"/{servicePath}";
+            BasePath = servicePath.StartsWith("/") ? servicePath : $"/{servicePath}";
         }
-
-        /// <summary>
-        ///     Path of this service
-        /// </summary>
-        public string ServicePath { get; set; }
     }
 }

--- a/src/SwaggerWcf/Attributes/SwaggerWcfContactInfoAttribute.cs
+++ b/src/SwaggerWcf/Attributes/SwaggerWcfContactInfoAttribute.cs
@@ -1,0 +1,37 @@
+﻿using SwaggerWcf.Models;
+using System;
+
+namespace SwaggerWcf.Attributes
+{
+    /// <summary>
+    /// Provides values for Contact information for the exposed API.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
+    public class SwaggerWcfContactInfoAttribute : Attribute
+    {
+        /// <summary>
+        /// The identifying name of the contact person/organization.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The email address of the contact person/organization. MUST be in the format of an email address.
+        /// </summary>
+        public string Email { get; set; }
+
+        /// <summary>
+        /// The URL pointing to the contact information. MUST be in the format of a URL.
+        /// </summary>
+        public string Url { get; set; }
+
+        public static explicit operator InfoContact(SwaggerWcfContactInfoAttribute attr)
+        {
+            return new InfoContact
+            {
+                Name = attr.Name,
+                Url = attr.Url,
+                Email = attr.Email
+            };
+        }
+    }
+}

--- a/src/SwaggerWcf/Attributes/SwaggerWcfLicenseInfoAttribute.cs
+++ b/src/SwaggerWcf/Attributes/SwaggerWcfLicenseInfoAttribute.cs
@@ -1,0 +1,45 @@
+﻿using SwaggerWcf.Models;
+using System;
+
+namespace SwaggerWcf.Attributes
+{
+    /// <summary>
+    /// Provides values for License information for the exposed API.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
+    public class SwaggerWcfLicenseInfoAttribute : Attribute
+    {
+        /// <summary>
+        /// Required. The license name used for the API.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// A URL to the license used for the API. MUST be in the format of a URL.
+        /// </summary>
+        public string Url { get; set; }
+
+        /// <summary>
+        ///  Provides values for License information for the exposed API.
+        /// </summary>
+        /// <param name="name">The license name used for the API.</param>
+        public SwaggerWcfLicenseInfoAttribute(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            Name = name;
+        }
+
+        public static explicit operator InfoLicense(SwaggerWcfLicenseInfoAttribute attr)
+        {
+            return new InfoLicense
+            {
+                Name = attr.Name,
+                Url = attr.Url
+            };
+        }
+    }
+}

--- a/src/SwaggerWcf/Attributes/SwaggerWcfServiceInfoAttribute.cs
+++ b/src/SwaggerWcf/Attributes/SwaggerWcfServiceInfoAttribute.cs
@@ -1,0 +1,58 @@
+﻿using SwaggerWcf.Models;
+using System;
+
+namespace SwaggerWcf.Attributes
+{
+    /// <summary>
+    /// Provides metadata about the API. The metadata can be used by the clients if needed.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
+    public class SwaggerWcfServiceInfoAttribute : Attribute
+    {
+        /// <summary>
+        /// Required. The title of the application.
+        /// </summary>
+        public string Title { get; }
+
+        /// <summary>
+        /// Required Provides the version of the application API (not to be confused with the specification version).
+        /// </summary>
+        public string Version { get; }
+
+        /// <summary>
+        /// A short description of the application. GFM syntax can be used for rich text representation.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The Terms of Service for the API.
+        /// </summary>
+        public string TermsOfService { get; set; }
+
+        /// <summary>
+        /// Assigns service info values
+        /// </summary>
+        /// <param name="title">The title of the application</param>
+        /// <param name="version">Provides the version of the application API (not to be confused with the specification version)</param>
+        public SwaggerWcfServiceInfoAttribute(string title, string version)
+        {
+            if (string.IsNullOrWhiteSpace(title))
+                throw new ArgumentNullException(nameof(title));
+
+            if (string.IsNullOrWhiteSpace(version))
+                throw new ArgumentNullException(nameof(version));
+
+            Title = title;
+            Version = version;
+        }
+
+        public static explicit operator Info(SwaggerWcfServiceInfoAttribute attribute) =>
+            new Info
+            {
+                Title = attribute.Title,
+                Version = attribute.Version,
+                Description = attribute.Description,
+                TermsOfService = attribute.TermsOfService
+            };
+    }
+}

--- a/src/SwaggerWcf/Models/InfoContact.cs
+++ b/src/SwaggerWcf/Models/InfoContact.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
+using System;
 
 namespace SwaggerWcf.Models
 {
@@ -9,7 +10,15 @@ namespace SwaggerWcf.Models
 
         public string Email { get; set; }
 
-        public string Url { get; set; }
+        public string Url
+        {
+            get => _url;
+            set => _url = Uri.TryCreate(value, UriKind.Absolute, out Uri _)
+                    ? value
+                    : throw new ArgumentException("Value must be in the format of a URL", nameof(Url));
+        }
+
+        private string _url;
 
         internal void Serialize(JsonWriter writer)
         {

--- a/src/SwaggerWcf/Models/InfoLicense.cs
+++ b/src/SwaggerWcf/Models/InfoLicense.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
+using System;
 
 namespace SwaggerWcf.Models
 {
@@ -7,7 +8,15 @@ namespace SwaggerWcf.Models
     {
         public string Name { get; set; }
 
-        public string Url { get; set; }
+        public string Url
+        {
+            get => _url;
+            set => _url = Uri.TryCreate(value, UriKind.Absolute, out Uri _)
+                    ? value
+                    : throw new ArgumentException("Value must be in the format of a URL", nameof(Url));
+        }
+
+        private string _url;
 
         internal void Serialize(JsonWriter writer)
         {

--- a/src/SwaggerWcf/Models/Service.cs
+++ b/src/SwaggerWcf/Models/Service.cs
@@ -23,7 +23,7 @@ namespace SwaggerWcf.Models
 
         public List<string> Schemes { get; set; }
 
-	public List<Path> Paths { get; set; }
+        public List<Path> Paths { get; set; }
 
         public List<Definition> Definitions { get; set; }
 
@@ -50,7 +50,7 @@ namespace SwaggerWcf.Models
                 writer.WritePropertyName("basePath");
                 writer.WriteValue(BasePath);
             }
-	    if (Schemes != null && Schemes.Any())
+            if (Schemes != null && Schemes.Any())
             {
                 writer.WritePropertyName("schemes");
                 writer.WriteStartArray();

--- a/src/SwaggerWcf/Support/ServiceBuilder.cs
+++ b/src/SwaggerWcf/Support/ServiceBuilder.cs
@@ -128,9 +128,13 @@ namespace SwaggerWcf.Support
                     if (da == null || hiddenTags.Any(ht => ht == ti.AsType().Name))
                         continue;
 
-                    Mapper mapper = new Mapper(hiddenTags, visibleTags);
+                    if (service.Info is null)
+                    {
+                        service.Info = ti.GetServiceInfo();
+                    }
 
-                    IEnumerable<Path> paths = mapper.FindMethods(da.ServicePath, ti.AsType(), definitionsTypesList);
+                    Mapper mapper = new Mapper(hiddenTags, visibleTags);
+                    IEnumerable<Path> paths = mapper.FindMethods(da.BasePath, ti.AsType(), definitionsTypesList);
                     service.Paths.AddRange(paths);
                 }
             }
@@ -147,7 +151,7 @@ namespace SwaggerWcf.Support
 
             Mapper mapper = new Mapper(hiddenTags, visibleTags);
 
-            IEnumerable<Path> paths = mapper.FindMethods(da.ServicePath, type, definitionsTypesList);
+            IEnumerable<Path> paths = mapper.FindMethods(da.BasePath, type, definitionsTypesList);
             service.Paths.AddRange(paths);
         }
     }

--- a/src/SwaggerWcf/Support/TypeExtensions.cs
+++ b/src/SwaggerWcf/Support/TypeExtensions.cs
@@ -38,6 +38,12 @@ namespace SwaggerWcf.Support
                 info.Contact = (InfoContact)contactAttr;
             }
 
+            var licenseAttr = typeInfo.GetCustomAttribute<SwaggerWcfLicenseInfoAttribute>();
+            if (licenseAttr != null)
+            {
+                info.License = (InfoLicense)licenseAttr;
+            }
+
             return info;
         }
     }

--- a/src/SwaggerWcf/Support/TypeExtensions.cs
+++ b/src/SwaggerWcf/Support/TypeExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using SwaggerWcf.Attributes;
+using SwaggerWcf.Models;
 using System;
 using System.Linq;
 using System.Reflection;
@@ -23,5 +24,15 @@ namespace SwaggerWcf.Support
 
         public static string GetModelWrappedName(this Type type) =>
             type.GetCustomAttribute<SwaggerWcfDefinitionAttribute>()?.ModelName ?? type.FullName;
+
+        internal static Info GetServiceInfo(this TypeInfo typeInfo)
+        {
+            var infoAttr = typeInfo.GetCustomAttribute<SwaggerWcfServiceInfoAttribute>() ??
+                throw new ArgumentException($"{typeInfo.FullName} does not have {nameof(SwaggerWcfServiceInfoAttribute)}");
+
+            Info info = (Info)infoAttr;
+
+            return info;
+        }
     }
 }

--- a/src/SwaggerWcf/Support/TypeExtensions.cs
+++ b/src/SwaggerWcf/Support/TypeExtensions.cs
@@ -30,7 +30,13 @@ namespace SwaggerWcf.Support
             var infoAttr = typeInfo.GetCustomAttribute<SwaggerWcfServiceInfoAttribute>() ??
                 throw new ArgumentException($"{typeInfo.FullName} does not have {nameof(SwaggerWcfServiceInfoAttribute)}");
 
-            Info info = (Info)infoAttr;
+            var info = (Info)infoAttr;
+
+            var contactAttr = typeInfo.GetCustomAttribute<SwaggerWcfContactInfoAttribute>();
+            if (contactAttr != null)
+            {
+                info.Contact = (InfoContact)contactAttr;
+            }
 
             return info;
         }

--- a/src/SwaggerWcf/SwaggerWcf.csproj
+++ b/src/SwaggerWcf/SwaggerWcf.csproj
@@ -56,6 +56,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Attributes\SwaggerWcfContactInfoAttribute.cs" />
     <Compile Include="Attributes\SwaggerWcfServiceInfoAttribute.cs" />
     <Compile Include="Attributes\SwaggerWcfRequestTypeAttribute.cs" />
     <Compile Include="Attributes\SwaggerWcfSecurityAttribute.cs" />

--- a/src/SwaggerWcf/SwaggerWcf.csproj
+++ b/src/SwaggerWcf/SwaggerWcf.csproj
@@ -56,6 +56,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Attributes\SwaggerWcfServiceInfoAttribute.cs" />
     <Compile Include="Attributes\SwaggerWcfRequestTypeAttribute.cs" />
     <Compile Include="Attributes\SwaggerWcfSecurityAttribute.cs" />
     <Compile Include="Attributes\SwaggerWcfContentTypesAttribute.cs" />

--- a/src/SwaggerWcf/SwaggerWcf.csproj
+++ b/src/SwaggerWcf/SwaggerWcf.csproj
@@ -57,6 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attributes\SwaggerWcfContactInfoAttribute.cs" />
+    <Compile Include="Attributes\SwaggerWcfLicenseInfoAttribute.cs" />
     <Compile Include="Attributes\SwaggerWcfServiceInfoAttribute.cs" />
     <Compile Include="Attributes\SwaggerWcfRequestTypeAttribute.cs" />
     <Compile Include="Attributes\SwaggerWcfSecurityAttribute.cs" />

--- a/src/SwaggerWcf/SwaggerWcfEndpoint.cs
+++ b/src/SwaggerWcf/SwaggerWcfEndpoint.cs
@@ -52,7 +52,7 @@ namespace SwaggerWcf
         internal static void Init(Func<string, Service> buildService)
         {
             string[] paths = GetAllPaths().Where(p => !SwaggerFiles.Keys.Contains(p)).ToArray();
-            
+
             foreach (string path in paths)
             {
                 Service service = buildService(path);


### PR DESCRIPTION
Adds more attributes to generate Swagger schema using reflection without running the web service.

#### Changes:

- Added `SwaggerWcfServiceInfoAttribute`
- Added `SwaggerWcfContactInfoAttribute`
- Added `SwaggerWcfLicenseInfoAttribute`

#### Notes

- `swagger.info.title` and `swagger.info.version` are required metadata for API and should be in constructor of `[SwaggerWcf]`. Implementing this would be a breaking change.
