### PR TITLE
Show RegularExpressionAttribute pattern in hints

### DIFF
--- a/src/SwaggerWcf.Test.Service/Data/Book.cs
+++ b/src/SwaggerWcf.Test.Service/Data/Book.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 using SwaggerWcf.Attributes;
 
@@ -11,6 +12,7 @@ namespace SwaggerWcf.Test.Service.Data
     {
         [DataMember]
         [Description("Book ID")]
+        [RegularExpression("[\\w\\d]*")]
         public string Id { get; set; }
 
         [DataMember]

--- a/src/SwaggerWcf.Test.Service/SwaggerWcf.Test.Service.csproj
+++ b/src/SwaggerWcf.Test.Service/SwaggerWcf.Test.Service.csproj
@@ -44,6 +44,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.ServiceModel.Activation" />
     <Reference Include="System.Web.DynamicData" />

--- a/src/SwaggerWcf/Support/TypeFieldsProcessor.cs
+++ b/src/SwaggerWcf/Support/TypeFieldsProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -94,6 +95,10 @@ namespace SwaggerWcf.Support
             DescriptionAttribute descriptionAttribute = propertyInfo.GetCustomAttribute<DescriptionAttribute>();
             if (descriptionAttribute != null)
                 prop.Description = descriptionAttribute.Description;
+
+            RegularExpressionAttribute regularExpressionAttribute = propertyInfo.GetCustomAttribute<RegularExpressionAttribute>();
+            if (regularExpressionAttribute != null)
+                prop.Pattern = regularExpressionAttribute.Pattern;
 
             prop.TypeFormat = typeFormat;
 

--- a/src/SwaggerWcf/Support/TypePropertiesProcessor.cs
+++ b/src/SwaggerWcf/Support/TypePropertiesProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -94,6 +95,10 @@ namespace SwaggerWcf.Support
             DescriptionAttribute descriptionAttribute = propertyInfo.GetCustomAttribute<DescriptionAttribute>();
             if (descriptionAttribute != null)
                 prop.Description = descriptionAttribute.Description;
+
+            RegularExpressionAttribute regularExpressionAttribute = propertyInfo.GetCustomAttribute<RegularExpressionAttribute>();
+            if (regularExpressionAttribute != null)
+                prop.Pattern = regularExpressionAttribute.Pattern;
 
             prop.TypeFormat = typeFormat;
 

--- a/src/SwaggerWcf/SwaggerWcf.csproj
+++ b/src/SwaggerWcf/SwaggerWcf.csproj
@@ -36,6 +36,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />


### PR DESCRIPTION
SwaggerWcfProperty.Pattern doesnt use regular expression for checking.
So when we need to check data by Regexp and want to avoid duplication of pattern in SwaggerWcfPropertyAttribute and RegularExpressionAttribute, just use RegularExpressionAttribute.