### PR TITLE
Fixes for wcf configuration elements and properties processor

### DIFF
--- a/src/SwaggerWcf/Configuration/SettingCollection.cs
+++ b/src/SwaggerWcf/Configuration/SettingCollection.cs
@@ -3,7 +3,7 @@ using System.Configuration;
 
 namespace SwaggerWcf.Configuration
 {
-    [ConfigurationCollection(typeof(TagElement), AddItemName = "setting")]
+    [ConfigurationCollection(typeof(SettingElement), AddItemName = "setting")]
     public class SettingCollection : ConfigurationElementCollection
     {
         protected override ConfigurationElement CreateNewElement()

--- a/src/SwaggerWcf/Support/Mapper.cs
+++ b/src/SwaggerWcf/Support/Mapper.cs
@@ -144,7 +144,8 @@ namespace SwaggerWcf.Support
 
                 methodTags = methodTags.Distinct().ToList();
 
-                if (methodTags.Select(t => t.TagName).Any(HiddenTags.Contains))
+                if ((methodTags.Count == 0 && HiddenTags.Contains("default"))
+                    || methodTags.Select(t => t.TagName).Any(HiddenTags.Contains))
                     continue;
 
                 //if the method is marked Hidden anywhere, skip it

--- a/src/SwaggerWcf/Support/TypePropertiesProcessor.cs
+++ b/src/SwaggerWcf/Support/TypePropertiesProcessor.cs
@@ -20,7 +20,15 @@ namespace SwaggerWcf.Support
 
             foreach (PropertyInfo propertyInfo in properties)
             {
-                DefinitionProperty prop = ProcessProperty(propertyInfo, hiddenTags, typesStack);
+                DefinitionProperty prop = null;
+                try
+                {
+                    prop = ProcessProperty(propertyInfo, hiddenTags, typesStack);
+                }
+                catch
+                {
+                    continue;
+                }
 
                 if (prop == null)
                     continue;
@@ -134,8 +142,8 @@ namespace SwaggerWcf.Support
 
                 Type propType = propertyInfo.PropertyType;
 
-                if (propType.IsGenericType && (propType.GetGenericTypeDefinition() == typeof(Nullable<>) || propType.GetGenericTypeDefinition() == typeof(List<>)))
-                    propType = propType.GetEnumerableType();
+                if (propType.IsGenericType && (propType.GetGenericTypeDefinition() == typeof(Nullable<>) || propType.GetGenericTypeDefinition() == typeof(IEnumerable<>)))
+                    propType = propType.GenericTypeArguments.FirstOrDefault() ?? propType.GetEnumerableType();
 
                 string enumDescription = "";
                 List<string> listOfEnumNames = propType.GetEnumNames().ToList();


### PR DESCRIPTION
- in SettingCollection configuration element change type of element to SettingElement instead of TagElement

- fix generic contract type:
 - add support for IEnumerable
 - ignore if failed to retrieve

- do not show default api if hidden in config