### PR TITLE
fix, which avoids 2 exeptions in borderline cases

### DIFF
--- a/src/SwaggerWcf/Support/TypeBuilder.cs
+++ b/src/SwaggerWcf/Support/TypeBuilder.cs
@@ -69,6 +69,12 @@ namespace SwaggerWcf.Support
 
         private static void CreateProperty(System.Reflection.Emit.TypeBuilder tb, string propertyName, Type propertyType, bool required)
         {
+
+            if (propertyType.IsByRef) {
+              //avoids an exception in code below when by ref parameters are used
+              propertyType = propertyType.GetElementType();
+            }
+
             FieldBuilder fieldBuilder = tb.DefineField("_" + propertyName, propertyType, FieldAttributes.Private);
 
             PropertyBuilder propertyBuilder = tb.DefineProperty(propertyName, PropertyAttributes.HasDefault, propertyType, null);


### PR DESCRIPTION
1) EX in broken assembly reference tree
2) EX when byRef params in WCF signatures